### PR TITLE
Remove outline on focused state of input

### DIFF
--- a/lib/magic-input.styl
+++ b/lib/magic-input.styl
@@ -126,6 +126,9 @@ $mgcSwitchHeight ?= 24px;
             transform: translateX(17px);
         }
     }
+    &:focus{
+        outline: 0;
+    }
 }
 
 $mgcSwitchHeight =20px


### PR DESCRIPTION
To work properly `outline: 0` rule should be applied to focused state of input, read more: http://stackoverflow.com/a/21758143/1331425
